### PR TITLE
Only display ranks reward in stats menu if unlocked.

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@
             </div>
         </div><div id="tab_frame1">
             <div id="stab_frame1_0">
-                <button onclick="player.ranks_reward = Math.max(player.ranks_reward-1,0)" class="btn"><--</button><span id="ranks_reward_name" style="margin: 0px 10px">aaa</span><button onclick="player.ranks_reward = Math.min(player.ranks_reward+1,RANKS.names.length-1)" class="btn">--></button><br><br>
+                <button onclick="player.ranks_reward = Math.max(player.ranks_reward-1,0)" class="btn"><--</button><span id="ranks_reward_name" style="margin: 0px 10px">aaa</span><button onclick="player.ranks_reward = Math.min(player.ranks_reward+1,Math.max(...RANKS.names.map((v, i) => i==0 ? i : (RANKS.unl[v]() && i))))" class="btn">--></button><br><br>
                 <div id="ranks_rewards_table"></div>
             </div><div id="stab_frame1_1">
                 <button onclick="player.scaling_ch = Math.max(player.scaling_ch-1,0)" class="btn"><--</button><span id="scaling_name" style="margin: 0px 10px">aaa</span><button onclick="player.scaling_ch = Math.min(player.scaling_ch+1,SCALE_TYPE.length-1)" class="btn">--></button><br><br>


### PR DESCRIPTION
When I was first playing this great game I opened the stats menu and scrolled all the way to the Pent. I feel like this is detrimental to the unfolding aspect to the game as it spoils the names of later resources and provides a guide to how long the game will last. If this is intentional, that is also okay, but I recommend only showing one or two resources in the future that the player has not yet unlocked. 

Before my feature for new save:
In stats menu:
Rank --> Tier --> Tetr --> Pent
After my feature:
Only Rank (for my current save it goes Rank --> Tier --> Tetr as expected, my highest unlocked resource)

If you would prefer this to be added in a JavaScript file instead of the html file that can be arranged.