### PR TITLE
Only display unlocked scalings and turn arrows black if at first/last.

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,10 +243,10 @@
             </div>
         </div><div id="tab_frame1">
             <div id="stab_frame1_0">
-                <button onclick="player.ranks_reward = Math.max(player.ranks_reward-1,0)" class="btn"><--</button><span id="ranks_reward_name" style="margin: 0px 10px">aaa</span><button onclick="player.ranks_reward = Math.min(player.ranks_reward+1,Math.max(...RANKS.names.map((v, i) => i==0 ? i : (RANKS.unl[v]() && i))))" class="btn">--></button><br><br>
+                <button onclick="player.ranks_reward = Math.max(player.ranks_reward-1,0)" class="btn" id="ranks_left_arrow"><--</button><span id="ranks_reward_name" style="margin: 0px 10px">aaa</span><button onclick="player.ranks_reward = Math.min(player.ranks_reward+1,Math.max(...RANKS.names.map((v, i) => i==0 ? i : (RANKS.unl[v]() && i))))" class="btn" id="ranks_right_arrow">--></button><br><br>
                 <div id="ranks_rewards_table"></div>
             </div><div id="stab_frame1_1">
-                <button onclick="player.scaling_ch = Math.max(player.scaling_ch-1,0)" class="btn"><--</button><span id="scaling_name" style="margin: 0px 10px">aaa</span><button onclick="player.scaling_ch = Math.min(player.scaling_ch+1,SCALE_TYPE.length-1)" class="btn">--></button><br><br>
+                <button onclick="player.scaling_ch = Math.max(player.scaling_ch-1,0)" class="btn" id="scaling_left_arrow"><--</button><span id="scaling_name" style="margin: 0px 10px">aaa</span><button onclick="player.scaling_ch = Math.min(player.scaling_ch+1,Math.max(...SCALE_TYPE.map((type, i) => tmp.scaling[type].length > 0 ? i : -1)))" class="btn" id="scaling_right_arrow">--></button><br><br>
                 <div id="scaling_table"></div>
             </div>
         </div><div id="tab_frame2">

--- a/js/elements.js
+++ b/js/elements.js
@@ -252,6 +252,20 @@ function updateTickspeedHTML() {
 
 function updateRanksRewardHTML() {
 	tmp.el["ranks_reward_name"].setTxt(RANKS.fullNames[player.ranks_reward])
+
+	if (player.ranks_reward === 0) {
+		tmp.el.ranks_left_arrow.addClass("locked")
+	} else {
+		tmp.el.ranks_left_arrow.removeClass("locked")
+	}
+
+	const maxUnlockedRank = Math.max(...RANKS.names.map((v, i) => i==0 ? i : (RANKS.unl[v]() && i)))
+	if (player.ranks_reward === maxUnlockedRank) {
+		tmp.el.ranks_right_arrow.addClass("locked")
+	} else {
+		tmp.el.ranks_right_arrow.removeClass("locked")
+	}
+ 
 	for (let x = 0; x < RANKS.names.length; x++) {
 		let rn = RANKS.names[x]
 		tmp.el["ranks_reward_div_"+x].setDisplay(player.ranks_reward == x)

--- a/js/scaling.js
+++ b/js/scaling.js
@@ -67,6 +67,20 @@ const NAME_FROM_RES = {
 function updateScalingHTML() {
 	let s = SCALE_TYPE[player.scaling_ch]
 	tmp.el.scaling_name.setTxt(FULL_SCALE_NAME[player.scaling_ch])
+
+	if (player.scaling_ch === 0) {
+		tmp.el.scaling_left_arrow.addClass("locked")
+	} else {
+		tmp.el.scaling_left_arrow.removeClass("locked")
+	}
+
+	let maxActiveScaling = Math.max(...SCALE_TYPE.map((type, i) => tmp.scaling[type].length > 0 ? i : -1))
+	if (player.scaling_ch === maxActiveScaling) {
+		tmp.el.scaling_right_arrow.addClass("locked")
+	} else {
+		tmp.el.scaling_right_arrow.removeClass("locked")
+	}
+
 	if (!tmp.scaling) return
 	for (let x = 0; x < SCALE_TYPE.length; x++) {
 		tmp.el["scaling_div_"+x].setDisplay(player.scaling_ch == x)

--- a/style.css
+++ b/style.css
@@ -1,5 +1,6 @@
 :root {
     --font: 'Verdana, Geneva, Tahoma, sans-serif';
+	color-scheme: dark;
 }
 
 @font-face {


### PR DESCRIPTION
Applies the previous pr to scalings, so that it only displays scalings up to the highest active scalings. For example, it only shows _Super --> Hyper_ on my save. Note that since it looks at the length of the array of currently applied resources for each scaling, it may re-hide a previously active scaling on prestige / purchase of upgrade if the resource is no longer in the bracket to receive that scaling.

The grey background "purchasable" buttons and the black "expensive" buttons are a useful visual indicator to the user. This is why I added it to the arrows. If the user is at the lowest or highest unlocked scaling/rank_reward, the button is painted black, otherwise it is grey.
![image](https://user-images.githubusercontent.com/34364128/155075699-dc3dbcfe-2403-4957-b890-27b2f81386b7.png)
![image](https://user-images.githubusercontent.com/34364128/155075754-a8c3d6fc-b001-4ceb-966e-e7918a872bd7.png)
![image](https://user-images.githubusercontent.com/34364128/155075718-19bede9f-07c0-44f7-8844-bcb2a51c356e.png)

Turn the scrollbar to night theme.
![image](https://user-images.githubusercontent.com/34364128/155078668-b1c98d79-237f-43df-884f-79d92a8bf405.png)


Beware, if you merge this into the main branch, there is a small chance of merge conflicts when you try to merge v0.5 into main. I am willing to help if that does occur, but another solution is merging this code into v0.5 or only merging once v0.5 is already merged. 