### PR TITLE
Fix Element 54 description

### DIFF
--- a/js/elemental.js
+++ b/js/elemental.js
@@ -388,7 +388,7 @@ const ELEMENTS = {
             cost: E('e4600'),
         },
         {
-            desc: `Collapsed stars boost all-star resources at a reduced rate.`,
+            desc: `Normal mass boost all-star resources at a reduced rate.`,
             cost: E('e5200'),
             effect() {
                 let x = player.mass.max(1).log10().root(2)


### PR DESCRIPTION
It is boost based normal mass and not collapsed star, the stupid mistake RedShark have make and hasn't fixed since October 2021.